### PR TITLE
Implement sidebar pages and user settings

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -18,4 +18,13 @@ body {
 #sidebarToggle {
   border: none;
   box-shadow: none;
+  position: absolute;
+  left: 1rem;
+}
+.sidebar-heading {
+  font-size: 1.8rem;
+  font-weight: bold;
+}
+.navbar .container-fluid {
+  position: relative;
 }

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -12,7 +12,7 @@ if (!isset($_SESSION['user_id'])) {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Dashboard</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/litera/bootstrap.min.css" rel="stylesheet">
     <link href="../assets/custom.css" rel="stylesheet">
   </head>
   <body>
@@ -21,9 +21,8 @@ if (!isset($_SESSION['user_id'])) {
       <div class="bg-light border-end" id="sidebar-wrapper">
         <div class="sidebar-heading border-bottom bg-light">GPTest3</div>
         <div class="list-group list-group-flush">
-          <a href="#" class="list-group-item list-group-item-action list-group-item-light p-3">Dashboard</a>
-          <a href="#" class="list-group-item list-group-item-action list-group-item-light p-3">Profile</a>
-          <a href="#" class="list-group-item list-group-item-action list-group-item-light p-3">Settings</a>
+          <a href="dashboard.php" class="list-group-item list-group-item-action list-group-item-light p-3">Dashboard</a>
+          <a href="settings.php" class="list-group-item list-group-item-action list-group-item-light p-3">Ajustes</a>
         </div>
       </div>
       <!-- Page content -->
@@ -42,7 +41,7 @@ if (!isset($_SESSION['user_id'])) {
         </div>
       </div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../assets/custom.js"></script>
   </body>
 </html>

--- a/public/settings.php
+++ b/public/settings.php
@@ -1,0 +1,88 @@
+<?php
+require_once dirname(__DIR__) . '/config/database.php';
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$err = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'] ?? '';
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+    if ($name && $email && $password) {
+        $stmt = $pdo->prepare('INSERT INTO users (name, email, password) VALUES (?, ?, ?)');
+        $stmt->execute([$name, $email, $password]);
+    } else {
+        $err = 'Todos los campos son obligatorios';
+    }
+}
+$users = $pdo->query('SELECT id, name, email FROM users')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ajustes</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/litera/bootstrap.min.css" rel="stylesheet">
+  <link href="../assets/custom.css" rel="stylesheet">
+</head>
+<body>
+  <div class="d-flex" id="wrapper">
+    <!-- Sidebar -->
+    <div class="bg-light border-end" id="sidebar-wrapper">
+      <div class="sidebar-heading border-bottom bg-light">GPTest3</div>
+      <div class="list-group list-group-flush">
+        <a href="dashboard.php" class="list-group-item list-group-item-action list-group-item-light p-3">Dashboard</a>
+        <a href="settings.php" class="list-group-item list-group-item-action list-group-item-light p-3">Ajustes</a>
+      </div>
+    </div>
+    <!-- Page content -->
+    <div id="page-content-wrapper">
+      <nav class="navbar navbar-light bg-light border-bottom">
+        <div class="container-fluid d-flex align-items-center">
+          <button class="navbar-toggler me-2" type="button" id="sidebarToggle">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <span class="navbar-brand mb-0 h1">Ajustes</span>
+        </div>
+      </nav>
+      <div class="container-fluid mt-4">
+        <h1 class="mt-4">Ajustes</h1>
+        <?php if($err): ?>
+          <div class="alert alert-danger"><?= $err ?></div>
+        <?php endif; ?>
+        <h3>Usuarios</h3>
+        <table class="table table-striped">
+          <thead><tr><th>ID</th><th>Nombre</th><th>Email</th></tr></thead>
+          <tbody>
+          <?php foreach($users as $u): ?>
+            <tr><td><?= $u['id'] ?></td><td><?= htmlspecialchars($u['name']) ?></td><td><?= htmlspecialchars($u['email']) ?></td></tr>
+          <?php endforeach; ?>
+          </tbody>
+        </table>
+        <h4 class="mt-4">Nuevo usuario</h4>
+        <form method="POST">
+          <div class="mb-3">
+            <label class="form-label">Nombre</label>
+            <input type="text" class="form-control" name="name" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" class="form-control" name="email" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Contraseña</label>
+            <input type="text" class="form-control" name="password" required>
+          </div>
+          <button type="submit" class="btn btn-primary">Agregar</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="../assets/custom.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restyle dashboard with a Bootswatch theme
- enlarge sidebar title and keep sidebar toggle fixed
- add link to a new *Ajustes* page
- implement `settings.php` to list and create users

## Testing
- `php -l public/dashboard.php`
- `php -l public/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_684821d7a4d0832eb559d5b4298e4d7f